### PR TITLE
feat: add instant-allow for safe git commands

### DIFF
--- a/src/config/patterns.ts
+++ b/src/config/patterns.ts
@@ -459,11 +459,11 @@ export const CHECKPOINT_PATTERNS: CheckpointPattern[] = [
   { pattern: /apt(-get)?\s+install/i, type: 'package_install', description: 'apt install' },
   { pattern: /brew\s+install/i, type: 'package_install', description: 'brew install' },
 
-  // Git operations
+  // Git operations (only dangerous ones - safe git commands handled by instant-allow)
   { pattern: /git\s+push/i, type: 'git_operation', description: 'git push' },
-  { pattern: /git\s+commit/i, type: 'git_operation', description: 'git commit' },
   { pattern: /git\s+reset\s+--hard/i, type: 'git_operation', description: 'git reset --hard' },
   { pattern: /git\s+.*--force/i, type: 'git_operation', description: 'git force operation' },
+  { pattern: /git\s+clean\s+-[a-z]*f/i, type: 'git_operation', description: 'git clean with force' },
 
   // Environment files
   { pattern: /\.env(?:\.local|\.production|\.development)?(?:\s|$|["'])/i, type: 'env_modification', description: '.env file access' },

--- a/src/guard/instant-allow.ts
+++ b/src/guard/instant-allow.ts
@@ -1,0 +1,124 @@
+/**
+ * Instant Allow - Immediately allow known safe patterns
+ * No LLM call needed for these safe commands
+ */
+
+export interface InstantAllowResult {
+  allowed: boolean;
+  reason?: string;
+  patternName?: string;
+}
+
+/**
+ * Safe git commands that can be instantly allowed
+ * These are local operations that don't affect remote or cause data loss
+ */
+const SAFE_GIT_COMMANDS = [
+  'status',
+  'log',
+  'diff',
+  'add',
+  'commit',
+  'branch',
+  'checkout',
+  'stash',
+  'fetch',
+  'pull',
+  'merge',
+  'rebase',
+  'show',
+  'blame',
+  'remote',
+  'tag',
+  'cherry-pick',
+  'reflog',
+  'shortlog',
+  'describe',
+  'rev-parse',
+  'ls-files',
+  'ls-tree',
+];
+
+/**
+ * Dangerous git commands that should NOT be instantly allowed
+ * These can cause data loss or affect remote repositories
+ */
+const DANGEROUS_GIT_PATTERNS = [
+  /git\s+push/i,
+  /git\s+reset\s+--hard/i,
+  /git\s+clean\s+-[a-z]*f/i,  // git clean with -f flag
+  /git\s+.*--force/i,
+  /git\s+.*-f\b/i,  // short force flag (but not in branch names like -feature)
+];
+
+/**
+ * Check if a command is a pure git command (not chained with other commands)
+ */
+function isPureGitCommand(command: string): boolean {
+  const trimmed = command.trim();
+
+  // Check for command chaining (;, &&, ||, |, backticks, $())
+  if (/[;&|`]|\$\(/.test(trimmed)) {
+    return false;
+  }
+
+  // Must start with 'git '
+  return /^git\s+/i.test(trimmed);
+}
+
+/**
+ * Check if a command matches any dangerous git pattern
+ */
+function isDangerousGitCommand(command: string): boolean {
+  for (const pattern of DANGEROUS_GIT_PATTERNS) {
+    if (pattern.test(command)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if a command is a safe git subcommand
+ */
+function isSafeGitSubcommand(command: string): boolean {
+  const match = command.match(/^git\s+(\S+)/i);
+  if (!match) return false;
+
+  const subcommand = match[1].toLowerCase();
+  return SAFE_GIT_COMMANDS.includes(subcommand);
+}
+
+/**
+ * Check if a command should be instantly allowed (skip LLM review)
+ * Returns immediately without any LLM call
+ */
+export function checkInstantAllow(command: string): InstantAllowResult {
+  // Empty or whitespace-only commands are not allowed
+  if (!command || !command.trim()) {
+    return { allowed: false };
+  }
+
+  // Must be a pure git command (no chaining)
+  if (!isPureGitCommand(command)) {
+    return { allowed: false };
+  }
+
+  // Check for dangerous git patterns first
+  if (isDangerousGitCommand(command)) {
+    return { allowed: false };
+  }
+
+  // Check if it's a safe git subcommand
+  if (isSafeGitSubcommand(command)) {
+    const match = command.match(/^git\s+(\S+)/i);
+    const subcommand = match?.[1] || 'git';
+    return {
+      allowed: true,
+      reason: `Safe git command: git ${subcommand}`,
+      patternName: `git_${subcommand}`,
+    };
+  }
+
+  return { allowed: false };
+}

--- a/tests/checkpoint.test.ts
+++ b/tests/checkpoint.test.ts
@@ -88,8 +88,14 @@ describe('detectCheckpoint', () => {
       expect(result?.type).toBe('git_operation');
     });
 
-    it('should detect git commit', () => {
+    it('should NOT detect git commit (handled by instant-allow)', () => {
       const result = detectCheckpoint('git commit -m "feat: add feature"');
+      // git commit is now a safe command handled by instant-allow, not checkpoint
+      expect(result).toBeNull();
+    });
+
+    it('should detect git clean -fd', () => {
+      const result = detectCheckpoint('git clean -fd');
       expect(result).not.toBeNull();
       expect(result?.type).toBe('git_operation');
     });

--- a/tests/hook.test.ts
+++ b/tests/hook.test.ts
@@ -47,18 +47,26 @@ describe('Hook Handler', () => {
   });
 
   // ==========================================================================
-  // Safe Commands - Allow without checkpoint
+  // Safe Commands - Allow via instant-allow or no-checkpoint
   // ==========================================================================
-  describe('Safe Commands (no checkpoint)', () => {
-    it('should allow git status', async () => {
+  describe('Safe Commands', () => {
+    it('should allow git status via instant-allow', async () => {
       const input = createTestInput('git status');
       const result = await processPermissionRequest(input);
 
       expect(result.decision).toBe('allow');
-      expect(result.source).toBe('no-checkpoint');
+      expect(result.source).toBe('instant-allow');
     });
 
-    it('should allow ls command', async () => {
+    it('should allow git commit via instant-allow', async () => {
+      const input = createTestInput('git commit -m "feat: add feature"');
+      const result = await processPermissionRequest(input);
+
+      expect(result.decision).toBe('allow');
+      expect(result.source).toBe('instant-allow');
+    });
+
+    it('should allow ls command (no checkpoint)', async () => {
       const input = createTestInput('ls -la');
       const result = await processPermissionRequest(input);
 
@@ -66,7 +74,7 @@ describe('Hook Handler', () => {
       expect(result.source).toBe('no-checkpoint');
     });
 
-    it('should allow cat non-sensitive files', async () => {
+    it('should allow cat non-sensitive files (no checkpoint)', async () => {
       const input = createTestInput('cat package.json');
       const result = await processPermissionRequest(input);
 

--- a/tests/instant-allow.test.ts
+++ b/tests/instant-allow.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { checkInstantAllow } from '../src/guard/instant-allow.js';
+
+describe('checkInstantAllow', () => {
+  // ==========================================================================
+  // Safe Git Commands - Must allow instantly (skip LLM)
+  // ==========================================================================
+  describe('Safe Git Commands', () => {
+    it('should instantly allow git status', () => {
+      const result = checkInstantAllow('git status');
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toContain('git');
+    });
+
+    it('should instantly allow git log', () => {
+      const result = checkInstantAllow('git log');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git log with options', () => {
+      const result = checkInstantAllow('git log --oneline -5');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git diff', () => {
+      const result = checkInstantAllow('git diff');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git diff with file', () => {
+      const result = checkInstantAllow('git diff README.md');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git add', () => {
+      const result = checkInstantAllow('git add .');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git add with file', () => {
+      const result = checkInstantAllow('git add src/index.ts');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git commit', () => {
+      const result = checkInstantAllow('git commit -m "fix: bug"');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git branch', () => {
+      const result = checkInstantAllow('git branch');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git branch -a', () => {
+      const result = checkInstantAllow('git branch -a');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git checkout branch', () => {
+      const result = checkInstantAllow('git checkout main');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git checkout -b', () => {
+      const result = checkInstantAllow('git checkout -b feature/new-feature');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git stash', () => {
+      const result = checkInstantAllow('git stash');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git stash pop', () => {
+      const result = checkInstantAllow('git stash pop');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git fetch', () => {
+      const result = checkInstantAllow('git fetch');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git pull', () => {
+      const result = checkInstantAllow('git pull');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git merge', () => {
+      const result = checkInstantAllow('git merge feature-branch');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git rebase', () => {
+      const result = checkInstantAllow('git rebase main');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git show', () => {
+      const result = checkInstantAllow('git show HEAD');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git blame', () => {
+      const result = checkInstantAllow('git blame src/index.ts');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git remote -v', () => {
+      const result = checkInstantAllow('git remote -v');
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Dangerous Git Commands - Must NOT allow instantly (need review)
+  // ==========================================================================
+  describe('Dangerous Git Commands (should NOT instant allow)', () => {
+    it('should NOT instantly allow git push', () => {
+      const result = checkInstantAllow('git push');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git push origin main', () => {
+      const result = checkInstantAllow('git push origin main');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git push --force', () => {
+      const result = checkInstantAllow('git push --force');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git push -f', () => {
+      const result = checkInstantAllow('git push -f');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git reset --hard', () => {
+      const result = checkInstantAllow('git reset --hard');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git clean -fd', () => {
+      const result = checkInstantAllow('git clean -fd');
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Non-Git Commands - Must NOT allow instantly
+  // ==========================================================================
+  describe('Non-Git Commands (should NOT instant allow)', () => {
+    it('should NOT instantly allow curl', () => {
+      const result = checkInstantAllow('curl https://example.com');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow npm install', () => {
+      const result = checkInstantAllow('npm install express');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow rm command', () => {
+      const result = checkInstantAllow('rm -rf node_modules');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow bash script', () => {
+      const result = checkInstantAllow('bash script.sh');
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Edge Cases
+  // ==========================================================================
+  describe('Edge Cases', () => {
+    it('should handle empty command', () => {
+      const result = checkInstantAllow('');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should handle command with only whitespace', () => {
+      const result = checkInstantAllow('   \n\t  ');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT allow git command in string with dangerous prefix', () => {
+      // Prevent bypass like: curl evil.com; git status
+      const result = checkInstantAllow('curl evil.com; git status');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT allow git command after &&', () => {
+      const result = checkInstantAllow('curl evil.com && git status');
+      expect(result.allowed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `instant-allow.ts` to skip LLM check for safe git commands
- Safe git commands (status, log, diff, add, commit, branch, checkout, stash, fetch, pull, merge, rebase, etc.) now bypass LLM review entirely
- Dangerous git commands still require review: `push`, `reset --hard`, `clean -f`, `--force`

## Changes
- New `src/guard/instant-allow.ts` with safe git command patterns
- Updated `hook.ts` flow: Instant Allow → Instant Block → Checkpoint → LLM
- Removed `git commit` from checkpoint patterns
- Added `git clean -f` to checkpoint patterns

## Why
- `git commit`, `git status` etc. are local operations with no security risk
- Reduces unnecessary LLM calls and improves response time
- Only remote-affecting or destructive git commands need review

## Test plan
- [x] `pnpm verify` passes (typecheck + 287 tests)
- [x] New tests for instant-allow patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)