### PR TITLE
fix: restrict instant-allow to read-only git commands

### DIFF
--- a/src/config/patterns.ts
+++ b/src/config/patterns.ts
@@ -597,11 +597,23 @@ export const CHECKPOINT_PATTERNS: CheckpointPattern[] = [
   { pattern: /apt(-get)?\s+install/i, type: 'package_install', description: 'apt install' },
   { pattern: /brew\s+install/i, type: 'package_install', description: 'brew install' },
 
-  // Git operations (only dangerous ones - safe git commands handled by instant-allow)
+  // Git operations - commands that can trigger hooks or affect remote/state
+  // SECURITY: git hooks (.git/hooks/) can execute arbitrary code
+  // Read-only commands (status, log, diff, show, blame) are handled by instant-allow
   { pattern: /git\s+push/i, type: 'git_operation', description: 'git push' },
+  { pattern: /git\s+commit/i, type: 'git_operation', description: 'git commit (triggers pre-commit, commit-msg hooks)' },
+  { pattern: /git\s+checkout/i, type: 'git_operation', description: 'git checkout (triggers post-checkout hook)' },
+  { pattern: /git\s+switch/i, type: 'git_operation', description: 'git switch (triggers post-checkout hook)' },
+  { pattern: /git\s+merge/i, type: 'git_operation', description: 'git merge (triggers pre-merge-commit, post-merge hooks)' },
+  { pattern: /git\s+rebase/i, type: 'git_operation', description: 'git rebase (triggers pre-rebase hook)' },
+  { pattern: /git\s+pull/i, type: 'git_operation', description: 'git pull (triggers post-merge hook)' },
+  { pattern: /git\s+fetch/i, type: 'git_operation', description: 'git fetch' },
   { pattern: /git\s+reset\s+--hard/i, type: 'git_operation', description: 'git reset --hard' },
   { pattern: /git\s+.*--force/i, type: 'git_operation', description: 'git force operation' },
   { pattern: /git\s+clean\s+-[a-z]*f/i, type: 'git_operation', description: 'git clean with force' },
+  { pattern: /git\s+stash/i, type: 'git_operation', description: 'git stash' },
+  { pattern: /git\s+cherry-pick/i, type: 'git_operation', description: 'git cherry-pick' },
+  { pattern: /git\s+add/i, type: 'git_operation', description: 'git add' },
 
   // Environment files
   { pattern: /\.env(?:\.local|\.production|\.development)?(?:\s|$|["'])/i, type: 'env_modification', description: '.env file access' },

--- a/src/guard/instant-allow.ts
+++ b/src/guard/instant-allow.ts
@@ -10,27 +10,23 @@ export interface InstantAllowResult {
 }
 
 /**
- * Safe git commands that can be instantly allowed
- * These are local operations that don't affect remote or cause data loss
+ * Safe git commands that can be instantly allowed (READ-ONLY ONLY)
+ *
+ * SECURITY: Only pure read-only commands are allowed here.
+ * Commands that can trigger git hooks (commit, checkout, merge, etc.)
+ * are NOT safe because .git/hooks/ scripts can execute arbitrary code.
+ *
+ * Excluded (can trigger hooks or modify state):
+ * - add, commit, checkout, switch, restore
+ * - fetch, pull, push, merge, rebase, cherry-pick
+ * - stash, tag, branch (with args), remote (with args)
  */
 const SAFE_GIT_COMMANDS = [
   'status',
   'log',
   'diff',
-  'add',
-  'commit',
-  'branch',
-  'checkout',
-  'stash',
-  'fetch',
-  'pull',
-  'merge',
-  'rebase',
   'show',
   'blame',
-  'remote',
-  'tag',
-  'cherry-pick',
   'reflog',
   'shortlog',
   'describe',

--- a/tests/checkpoint.test.ts
+++ b/tests/checkpoint.test.ts
@@ -88,10 +88,29 @@ describe('detectCheckpoint', () => {
       expect(result?.type).toBe('git_operation');
     });
 
-    it('should NOT detect git commit (handled by instant-allow)', () => {
+    it('should detect git commit (triggers hooks)', () => {
       const result = detectCheckpoint('git commit -m "feat: add feature"');
-      // git commit is now a safe command handled by instant-allow, not checkpoint
-      expect(result).toBeNull();
+      // git commit triggers pre-commit, commit-msg hooks - needs review
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('git_operation');
+    });
+
+    it('should detect git checkout (triggers hooks)', () => {
+      const result = detectCheckpoint('git checkout main');
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('git_operation');
+    });
+
+    it('should detect git merge (triggers hooks)', () => {
+      const result = detectCheckpoint('git merge feature-branch');
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('git_operation');
+    });
+
+    it('should detect git add', () => {
+      const result = detectCheckpoint('git add .');
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('git_operation');
     });
 
     it('should detect git clean -fd', () => {

--- a/tests/instant-allow.test.ts
+++ b/tests/instant-allow.test.ts
@@ -3,9 +3,9 @@ import { checkInstantAllow } from '../src/guard/instant-allow.js';
 
 describe('checkInstantAllow', () => {
   // ==========================================================================
-  // Safe Git Commands - Must allow instantly (skip LLM)
+  // Read-Only Git Commands - Must allow instantly (skip LLM)
   // ==========================================================================
-  describe('Safe Git Commands', () => {
+  describe('Read-Only Git Commands (instant allow)', () => {
     it('should instantly allow git status', () => {
       const result = checkInstantAllow('git status');
       expect(result.allowed).toBe(true);
@@ -32,71 +32,6 @@ describe('checkInstantAllow', () => {
       expect(result.allowed).toBe(true);
     });
 
-    it('should instantly allow git add', () => {
-      const result = checkInstantAllow('git add .');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git add with file', () => {
-      const result = checkInstantAllow('git add src/index.ts');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git commit', () => {
-      const result = checkInstantAllow('git commit -m "fix: bug"');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git branch', () => {
-      const result = checkInstantAllow('git branch');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git branch -a', () => {
-      const result = checkInstantAllow('git branch -a');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git checkout branch', () => {
-      const result = checkInstantAllow('git checkout main');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git checkout -b', () => {
-      const result = checkInstantAllow('git checkout -b feature/new-feature');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git stash', () => {
-      const result = checkInstantAllow('git stash');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git stash pop', () => {
-      const result = checkInstantAllow('git stash pop');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git fetch', () => {
-      const result = checkInstantAllow('git fetch');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git pull', () => {
-      const result = checkInstantAllow('git pull');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git merge', () => {
-      const result = checkInstantAllow('git merge feature-branch');
-      expect(result.allowed).toBe(true);
-    });
-
-    it('should instantly allow git rebase', () => {
-      const result = checkInstantAllow('git rebase main');
-      expect(result.allowed).toBe(true);
-    });
-
     it('should instantly allow git show', () => {
       const result = checkInstantAllow('git show HEAD');
       expect(result.allowed).toBe(true);
@@ -107,16 +42,117 @@ describe('checkInstantAllow', () => {
       expect(result.allowed).toBe(true);
     });
 
-    it('should instantly allow git remote -v', () => {
-      const result = checkInstantAllow('git remote -v');
+    it('should instantly allow git reflog', () => {
+      const result = checkInstantAllow('git reflog');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git shortlog', () => {
+      const result = checkInstantAllow('git shortlog -sn');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git describe', () => {
+      const result = checkInstantAllow('git describe --tags');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git rev-parse', () => {
+      const result = checkInstantAllow('git rev-parse HEAD');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git ls-files', () => {
+      const result = checkInstantAllow('git ls-files');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should instantly allow git ls-tree', () => {
+      const result = checkInstantAllow('git ls-tree HEAD');
       expect(result.allowed).toBe(true);
     });
   });
 
   // ==========================================================================
-  // Dangerous Git Commands - Must NOT allow instantly (need review)
+  // Git Commands That Can Trigger Hooks - Must NOT allow instantly
+  // SECURITY: These can execute arbitrary code via .git/hooks/
   // ==========================================================================
-  describe('Dangerous Git Commands (should NOT instant allow)', () => {
+  describe('Git Commands That Can Trigger Hooks (need review)', () => {
+    it('should NOT instantly allow git add (pre-commit prep)', () => {
+      const result = checkInstantAllow('git add .');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git commit (triggers hooks)', () => {
+      const result = checkInstantAllow('git commit -m "fix: bug"');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git checkout (triggers hooks)', () => {
+      const result = checkInstantAllow('git checkout main');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git checkout -b', () => {
+      const result = checkInstantAllow('git checkout -b feature/new');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git fetch (triggers hooks)', () => {
+      const result = checkInstantAllow('git fetch');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git pull (triggers hooks)', () => {
+      const result = checkInstantAllow('git pull');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git merge (triggers hooks)', () => {
+      const result = checkInstantAllow('git merge feature-branch');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git rebase (triggers hooks)', () => {
+      const result = checkInstantAllow('git rebase main');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git stash (modifies state)', () => {
+      const result = checkInstantAllow('git stash');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git stash pop', () => {
+      const result = checkInstantAllow('git stash pop');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git cherry-pick', () => {
+      const result = checkInstantAllow('git cherry-pick abc123');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git branch (can delete)', () => {
+      const result = checkInstantAllow('git branch -D feature');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git tag', () => {
+      const result = checkInstantAllow('git tag v1.0.0');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('should NOT instantly allow git remote add', () => {
+      const result = checkInstantAllow('git remote add origin url');
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Dangerous Git Commands - Must NOT allow instantly
+  // ==========================================================================
+  describe('Dangerous Git Commands (need review)', () => {
     it('should NOT instantly allow git push', () => {
       const result = checkInstantAllow('git push');
       expect(result.allowed).toBe(false);
@@ -188,7 +224,6 @@ describe('checkInstantAllow', () => {
     });
 
     it('should NOT allow git command in string with dangerous prefix', () => {
-      // Prevent bypass like: curl evil.com; git status
       const result = checkInstantAllow('curl evil.com; git status');
       expect(result.allowed).toBe(false);
     });


### PR DESCRIPTION
## Summary
**SECURITY FIX**: Git hooks (`.git/hooks/`) can execute arbitrary code when triggered by certain git commands.

### Changes
- Restrict instant-allow to **read-only commands only**
- Route hook-triggering commands through checkpoint for LLM review

### Instant-Allow (read-only, no hooks)
```
status, log, diff, show, blame, reflog, shortlog, describe, rev-parse, ls-files, ls-tree
```

### Now Requires Review (can trigger hooks)
```
commit    → pre-commit, commit-msg, post-commit
checkout  → post-checkout
merge     → pre-merge-commit, post-merge
rebase    → pre-rebase
pull      → post-merge
fetch, stash, cherry-pick, add
```

## Why This Matters
An attacker could:
1. Create a malicious repo with `.git/hooks/pre-commit`
2. Trick user into cloning it
3. `git commit` would execute the malicious hook

## Test Plan
- [x] `pnpm verify` passes (299 tests)
- [x] Read-only commands still instant-allow
- [x] Hook-triggering commands routed to checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)