### PR TITLE
feat: add risky URL pattern detection

### DIFF
--- a/src/config/domains.ts
+++ b/src/config/domains.ts
@@ -218,3 +218,40 @@ export function containsUrlShortener(command: string): { found: boolean; shorten
     shortenerUrls,
   };
 }
+
+/**
+ * Risky URL patterns that should trigger deeper review even from trusted domains
+ * These patterns indicate user-controlled content that could be malicious
+ */
+const RISKY_URL_PATTERNS: RegExp[] = [
+  // Raw file content from GitHub - can be any user's code
+  /raw\.githubusercontent\.com/i,
+  // GitHub gist raw content
+  /gist\.github\.com\/[^/]+\/[^/]+\/raw/i,
+  // GitHub releases downloads - binary files from any user
+  /github\.com\/[^/]+\/[^/]+\/releases\/download/i,
+  // GitHub objects (blobs, etc.)
+  /objects\.githubusercontent\.com/i,
+  // Installer script patterns (get.*.sh)
+  /\/get\.[^/]+\.sh/i,
+];
+
+/**
+ * Check if a URL matches risky patterns that need deeper review
+ * Even if the domain is trusted, these URLs serve user-controlled content
+ */
+export function isRiskyUrlPattern(url: string): boolean {
+  return RISKY_URL_PATTERNS.some((pattern) => pattern.test(url));
+}
+
+/**
+ * Check if command contains any risky URL patterns
+ */
+export function containsRiskyUrlPattern(command: string): { found: boolean; riskyUrls: string[] } {
+  const urls = extractUrls(command);
+  const riskyUrls = urls.filter((url) => isRiskyUrlPattern(url));
+  return {
+    found: riskyUrls.length > 0,
+    riskyUrls,
+  };
+}

--- a/src/guard/trusted-domain.ts
+++ b/src/guard/trusted-domain.ts
@@ -46,4 +46,4 @@ export function checkTrustedDomains(command: string): TrustedDomainResult {
 }
 
 // Re-export for convenience
-export { isTrustedUrl, extractUrls };
+export { isTrustedUrl, extractUrls, isRiskyUrlPattern, containsRiskyUrlPattern } from '../config/domains.js';


### PR DESCRIPTION
## Summary
- Added detection for risky URL patterns that need deeper review even from trusted domains
- URLs serving user-controlled content are now flagged regardless of trusted domain status

## Risky Patterns Detected
- `raw.githubusercontent.com` - raw file content from any GitHub repo
- `gist.github.com/.../raw` - gist raw content
- `github.com/.../releases/download` - binary releases
- `objects.githubusercontent.com` - GitHub blobs
- `/get.*.sh` - installer script patterns

## Changes
- `src/config/domains.ts`: Added `RISKY_URL_PATTERNS`, `isRiskyUrlPattern()`, `containsRiskyUrlPattern()`
- `src/guard/trusted-domain.ts`: Re-exported new functions
- `tests/trusted-domain.test.ts`: Added 12 tests for risky URL patterns

## Test plan
- [x] `pnpm verify` passes (typecheck + tests)
- [x] Risky URL patterns correctly detected
- [x] Normal URLs not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)