### PR TITLE
feat: add progress indicator during LLM analysis

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -149,6 +149,9 @@ export async function processPermissionRequest(
     };
   }
 
+  // Progress indicator to stderr (doesn't interfere with JSON output on stdout)
+  process.stderr.write('\x1b[90m[VibeSafu] Assessing security risks...\x1b[0m\n');
+
   // Step 5a: Haiku triage
   const triage = await triageWithHaiku(anthropicClient, checkpoint);
 
@@ -169,6 +172,7 @@ export async function processPermissionRequest(
   }
 
   // Step 5b: Escalate to Sonnet for deeper review
+  process.stderr.write('\x1b[90m[VibeSafu] Escalating to deep analysis...\x1b[0m\n');
   const review = await reviewWithSonnet(anthropicClient, checkpoint, triage);
 
   if (review.verdict === 'BLOCK') {


### PR DESCRIPTION
## Summary
Added progress messages to stderr during security analysis so users know the review is in progress.

## Changes
Shows status messages during LLM analysis:
- `[VibeSafu] Assessing security risks...` - when Haiku triage starts
- `[VibeSafu] Escalating to deep analysis...` - when forwarding to Sonnet

Messages are output to stderr (gray color) so they don't interfere with JSON output on stdout.

## Test plan
- [x] `pnpm verify` passes
- [ ] Manual test: run vibesafu with a command that triggers LLM analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)