### PR TITLE
feat: add npm run, make, cp sensitive file checkpoints

### DIFF
--- a/src/config/patterns.ts
+++ b/src/config/patterns.ts
@@ -584,6 +584,8 @@ export const CHECKPOINT_PATTERNS: CheckpointPattern[] = [
   { pattern: /chmod\s+\+x/i, type: 'script_execution', description: 'Making file executable' },
   { pattern: /\.\/[^\s]+\.sh/i, type: 'script_execution', description: 'Running shell script' },
   { pattern: /bash\s+[^\s]+\.sh/i, type: 'script_execution', description: 'Running shell script with bash' },
+  { pattern: /npm\s+run\b/i, type: 'script_execution', description: 'npm run (executes package.json scripts)' },
+  { pattern: /\bmake\b/i, type: 'script_execution', description: 'make (executes Makefile)' },
 
   // Network operations
   { pattern: /curl\s+.*?(https?:\/\/[^\s"']+)/i, type: 'network', description: 'curl HTTP request' },
@@ -623,4 +625,9 @@ export const CHECKPOINT_PATTERNS: CheckpointPattern[] = [
   { pattern: /\.aws/i, type: 'file_sensitive', description: 'AWS credentials access' },
   { pattern: /credentials/i, type: 'file_sensitive', description: 'Credentials file access' },
   { pattern: /CLAUDE\.md/i, type: 'file_sensitive', description: 'CLAUDE.md modification' },
+
+  // Sensitive file copy/move (indirect path bypass)
+  { pattern: /(cp|mv)\s+.*\.ssh\//i, type: 'file_sensitive', description: 'Copying/moving SSH files' },
+  { pattern: /(cp|mv)\s+.*\.aws\//i, type: 'file_sensitive', description: 'Copying/moving AWS credentials' },
+  { pattern: /(cp|mv)\s+.*\.env(\s|$)/i, type: 'file_sensitive', description: 'Copying/moving .env file' },
 ];


### PR DESCRIPTION
## Summary
- **P1**: `npm run` triggers script_execution checkpoint (executes package.json scripts)
- **P1**: `make` triggers script_execution checkpoint (executes Makefile)
- **P3**: `cp`/`mv` sensitive files (.ssh, .aws, .env) triggers file_sensitive checkpoint

## Why
From feedbacks.md - these gaps allowed indirect bypass:
```bash
npm run postinstall  # executes unknown scripts
make                 # executes Makefile
cp ~/.ssh/id_rsa /tmp/key.txt  # copies sensitive file to bypass detection
```

## Test plan
- [x] `pnpm verify` passes (324 tests)
- [x] New tests for npm run, make, cp sensitive files

🤖 Generated with [Claude Code](https://claude.com/claude-code)