### PR TITLE
docs: fix FAQ about --dangerously-skip-permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,11 @@ Yes! VibeSafu works with both CLI (`claude`) and VS Code extension.
 
 ### Is this a replacement for `--dangerously-skip-permissions`?
 
-No. VibeSafu is an *addition* to `--dangerously-skip-permissions`. It lets you use that flag more safely by adding a security layer on top.
+Yes! That's exactly what VibeSafu is for. Instead of choosing between:
+- Annoying permission prompts for everything, OR
+- `--dangerously-skip-permissions` with zero protection
+
+VibeSafu gives you the middle ground: auto-approve safe commands, flag risky ones.
 
 ## ⭐ Like it? Star it!
 


### PR DESCRIPTION
## Summary
- Fix incorrect FAQ stating VibeSafu is an "addition" to `--dangerously-skip-permissions`
- VibeSafu is a **replacement** for that flag, not meant to be used together

## Before
> No. VibeSafu is an *addition* to `--dangerously-skip-permissions`. It lets you use that flag more safely by adding a security layer on top.

## After
> Yes! That's exactly what VibeSafu is for. Instead of choosing between:
> - Annoying permission prompts for everything, OR
> - `--dangerously-skip-permissions` with zero protection
>
> VibeSafu gives you the middle ground: auto-approve safe commands, flag risky ones.

## Test plan
- [ ] Verify README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)