### PR TITLE
refactor: architect review medium/low fixes

### DIFF
--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -3,7 +3,7 @@
  * Installs vibesafu hook to Claude Code settings
  */
 
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -56,6 +56,8 @@ async function writeClaudeSettings(settings: ClaudeSettings): Promise<void> {
   const dir = join(homedir(), '.claude');
   await mkdir(dir, { recursive: true });
   await writeFile(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2));
+  // Restrict permissions - settings may reference security-sensitive hooks
+  await chmod(CLAUDE_SETTINGS_PATH, 0o600);
 }
 
 /**

--- a/src/config/domains.ts
+++ b/src/config/domains.ts
@@ -175,11 +175,18 @@ export function isTrustedUrl(url: string): boolean {
 
 /**
  * Extract all URLs from a command string
+ * Strips trailing punctuation that is likely part of surrounding text, not the URL
  */
 export function extractUrls(command: string): string[] {
   const urlPattern = /https?:\/\/[^\s"'<>]+/gi;
   const matches = command.match(urlPattern);
-  return matches ?? [];
+  if (!matches) return [];
+
+  return matches.map((url) => {
+    // Strip trailing punctuation that is unlikely to be part of a URL
+    // Preserves . in filenames (e.g., file.tar.gz) by only stripping trailing single chars
+    return url.replace(/[),;.]+$/, '');
+  });
 }
 
 /**

--- a/src/config/patterns.ts
+++ b/src/config/patterns.ts
@@ -619,6 +619,19 @@ export const INSTANT_BLOCK_PATTERNS: BlockPattern[] = [
   ...SELF_PROTECTION_PATTERNS,
 ];
 
+// SAFETY: Verify no pattern uses the global (g) flag.
+// RegExp with 'g' flag is stateful: .test() alternates true/false on repeated calls.
+// This would cause intermittent security bypasses - a catastrophic bug for a security tool.
+for (const p of INSTANT_BLOCK_PATTERNS) {
+  if (p.pattern.global) {
+    throw new Error(
+      `Security pattern "${p.name}" must not use the global (g) flag. ` +
+      `The g flag makes RegExp.test() stateful, causing intermittent bypasses. ` +
+      `Remove the g flag from the pattern.`
+    );
+  }
+}
+
 // =============================================================================
 // Checkpoint Patterns - Trigger security review
 // =============================================================================
@@ -683,3 +696,13 @@ export const CHECKPOINT_PATTERNS: CheckpointPattern[] = [
   { pattern: /(cp|mv)\s+.*\.aws\//i, type: 'file_sensitive', description: 'Copying/moving AWS credentials' },
   { pattern: /(cp|mv)\s+.*\.env(\s|$)/i, type: 'file_sensitive', description: 'Copying/moving .env file' },
 ];
+
+for (const p of CHECKPOINT_PATTERNS) {
+  if (p.pattern.global) {
+    throw new Error(
+      `Checkpoint pattern "${p.description}" must not use the global (g) flag. ` +
+      `The g flag makes RegExp.test() stateful, causing intermittent bypasses. ` +
+      `Remove the g flag from the pattern.`
+    );
+  }
+}

--- a/src/guard/haiku-triage.ts
+++ b/src/guard/haiku-triage.ts
@@ -13,6 +13,7 @@
 
 import type Anthropic from '@anthropic-ai/sdk';
 import type { SecurityCheckpoint } from '../types.js';
+import { extractJsonFromText } from '../utils/sanitize.js';
 import {
   sanitizeForPrompt,
   shouldForceEscalate,
@@ -137,9 +138,9 @@ export async function triageWithHaiku(
       };
     }
 
-    // Extract JSON from response
-    const jsonMatch = text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
+    // Extract JSON from response using robust parser
+    const extracted = extractJsonFromText(text);
+    if (!extracted) {
       return {
         classification: 'ESCALATE',
         reason: 'Triage failed: Could not parse JSON response',
@@ -147,7 +148,7 @@ export async function triageWithHaiku(
       };
     }
 
-    const parsed = JSON.parse(jsonMatch[0]) as {
+    const parsed = extracted as {
       classification?: TriageClassification;
       reason?: string;
       risk_indicators?: string[];

--- a/src/guard/trusted-domain.ts
+++ b/src/guard/trusted-domain.ts
@@ -2,13 +2,16 @@
  * Trusted Domain - Check if URLs are from trusted sources
  */
 
-import { isTrustedUrl, extractUrls } from '../config/domains.js';
+import { isTrustedUrl, extractUrls, isRiskyUrlPattern } from '../config/domains.js';
 
 export interface TrustedDomainResult {
   allTrusted: boolean;
+  /** Whether any URL matches a risky pattern (user-controlled content from trusted domains) */
+  hasRiskyUrls: boolean;
   urls: string[];
   trustedUrls: string[];
   untrustedUrls: string[];
+  riskyUrls: string[];
 }
 
 /**
@@ -20,14 +23,17 @@ export function checkTrustedDomains(command: string): TrustedDomainResult {
   if (urls.length === 0) {
     return {
       allTrusted: true, // No URLs means nothing untrusted
+      hasRiskyUrls: false,
       urls: [],
       trustedUrls: [],
       untrustedUrls: [],
+      riskyUrls: [],
     };
   }
 
   const trustedUrls: string[] = [];
   const untrustedUrls: string[] = [];
+  const riskyUrls: string[] = [];
 
   for (const url of urls) {
     if (isTrustedUrl(url)) {
@@ -35,13 +41,19 @@ export function checkTrustedDomains(command: string): TrustedDomainResult {
     } else {
       untrustedUrls.push(url);
     }
+    // Check for risky patterns even on trusted domains
+    if (isRiskyUrlPattern(url)) {
+      riskyUrls.push(url);
+    }
   }
 
   return {
     allTrusted: untrustedUrls.length === 0,
+    hasRiskyUrls: riskyUrls.length > 0,
     urls,
     trustedUrls,
     untrustedUrls,
+    riskyUrls,
   };
 }
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -279,6 +279,16 @@ export async function processPermissionRequest(
   if (checkpoint.type === 'network') {
     const domainResult = checkTrustedDomains(command);
     if (domainResult.allTrusted && domainResult.urls.length > 0) {
+      // SECURITY: Even from trusted domains, risky URL patterns (raw.githubusercontent.com,
+      // releases/download, etc.) serve user-controlled content and need deeper review
+      if (domainResult.hasRiskyUrls) {
+        return {
+          decision: 'needs-review',
+          reason: `Risky URL pattern from trusted domain: ${domainResult.riskyUrls.join(', ')}`,
+          source: 'checkpoint',
+          checkpoint,
+        };
+      }
       return {
         decision: 'allow',
         reason: `All URLs from trusted domains: ${domainResult.trustedUrls.join(', ')}`,

--- a/tests/hook.test.ts
+++ b/tests/hook.test.ts
@@ -163,6 +163,21 @@ describe('Hook Handler', () => {
       expect(result.decision).toBe('allow');
       expect(result.source).toBe('trusted-domain');
     });
+
+    // Risky URL patterns should NOT be auto-approved even from trusted domains
+    it('should NOT auto-approve raw.githubusercontent.com (user-controlled content)', async () => {
+      const input = createTestInput('curl -o file.txt https://raw.githubusercontent.com/user/repo/main/script.sh');
+      const result = await processPermissionRequest(input);
+
+      expect(result.decision).toBe('needs-review');
+    });
+
+    it('should NOT auto-approve GitHub release downloads', async () => {
+      const input = createTestInput('curl -L -o binary https://github.com/user/repo/releases/download/v1.0/binary');
+      const result = await processPermissionRequest(input);
+
+      expect(result.decision).toBe('needs-review');
+    });
   });
 
   // ==========================================================================

--- a/tests/instant-block.test.ts
+++ b/tests/instant-block.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { checkHighRiskPatterns } from '../src/guard/instant-block.js';
+import { INSTANT_BLOCK_PATTERNS, CHECKPOINT_PATTERNS } from '../src/config/patterns.js';
 
 /** Thin adapter to keep test assertions concise */
 function checkInstantBlock(command: string) {
@@ -417,6 +418,23 @@ EOF`;
     it('should handle command with unicode characters', () => {
       const result = checkInstantBlock('echo "unicode test 🚀"');
       expect(result.blocked).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Regex Safety: No g-flag on any pattern
+  // ==========================================================================
+  describe('Regex Safety', () => {
+    it('should not use global flag on any INSTANT_BLOCK_PATTERNS', () => {
+      for (const p of INSTANT_BLOCK_PATTERNS) {
+        expect(p.pattern.global, `Pattern ${p.name} has global flag`).toBe(false);
+      }
+    });
+
+    it('should not use global flag on any CHECKPOINT_PATTERNS', () => {
+      for (const p of CHECKPOINT_PATTERNS) {
+        expect(p.pattern.global, `Pattern type=${p.type} has global flag`).toBe(false);
+      }
     });
   });
 });

--- a/tests/trusted-domain.test.ts
+++ b/tests/trusted-domain.test.ts
@@ -205,6 +205,32 @@ describe('Trusted Domain', () => {
       const urls = extractUrls('curl "https://example.com/file"');
       expect(urls).toContain('https://example.com/file');
     });
+
+    it('should strip trailing parenthesis from URLs', () => {
+      const urls = extractUrls('Visit (https://example.com/page)');
+      expect(urls).toContain('https://example.com/page');
+      expect(urls).not.toContain('https://example.com/page)');
+    });
+
+    it('should strip trailing comma from URLs', () => {
+      const urls = extractUrls('Download https://example.com/file, then run');
+      expect(urls).toContain('https://example.com/file');
+    });
+
+    it('should strip trailing semicolon from URLs', () => {
+      const urls = extractUrls('curl https://example.com/api; echo done');
+      expect(urls).toContain('https://example.com/api');
+    });
+
+    it('should strip trailing period from URLs', () => {
+      const urls = extractUrls('Check https://example.com/docs.');
+      expect(urls).toContain('https://example.com/docs');
+    });
+
+    it('should preserve URLs with valid trailing path chars', () => {
+      const urls = extractUrls('curl https://example.com/path/to/file.tar.gz');
+      expect(urls).toContain('https://example.com/path/to/file.tar.gz');
+    });
   });
 
   // ==========================================================================


### PR DESCRIPTION
## Summary

Remaining medium and low priority fixes from senior architect code review.

- **Robust LLM JSON extraction**: Replace greedy regex with `extractJsonFromText()` utility that tries direct parse, code block extraction, then balanced brace counting. Prevents misparse when LLM response contains extra braces in explanation text
- **URL extraction cleanup**: Strip trailing `)`, `;`, `.`, `,` from extracted URLs that are part of surrounding text, not the URL itself
- **Regex g-flag safety guard**: Add runtime assertion at module load to reject any security pattern with the `g` flag (stateful `test()` would cause intermittent bypasses)
- **Settings file permissions**: Add `chmod 0o600` on `~/.claude/settings.json` after write, consistent with config.ts
- **Risky URL patterns wired into pipeline**: `raw.githubusercontent.com`, `releases/download`, and other user-controlled content patterns now trigger checkpoint review even from trusted domains

## Test plan

- [x] `pnpm verify` passes (typecheck + 404 tests, up from 393)
- [ ] Verify LLM JSON extraction handles code blocks and balanced braces
- [ ] Verify URLs with trailing punctuation are cleaned correctly
- [ ] Verify adding `g` flag to any pattern throws at module load
- [ ] Verify `curl -o file https://raw.githubusercontent.com/...` triggers review
- [ ] Verify `curl https://api.github.com/...` (non-risky trusted) still auto-approves

🤖 Generated with [Claude Code](https://claude.com/claude-code)